### PR TITLE
possibility to change AES cipher key for remember me

### DIFF
--- a/src/main/groovy/shiro/ShiroGrailsPlugin.groovy
+++ b/src/main/groovy/shiro/ShiroGrailsPlugin.groovy
@@ -47,6 +47,8 @@ import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreato
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.core.Ordered
 
+import java.security.InvalidKeyException
+
 import static javax.servlet.DispatcherType.ERROR
 import static javax.servlet.DispatcherType.REQUEST
 
@@ -133,7 +135,15 @@ Enables Grails applications to take advantage of the Apache Shiro security layer
             }
 
             // Default remember-me manager.
-            shiroRememberMeManager(CookieRememberMeManager)
+            def cipherKeyFromConfig = grailsApplication.config.getProperty('security.shiro.rememberMe.cipherKey')
+            if (cipherKeyFromConfig) {
+                if (!(cipherKeyFromConfig.length() * 8 in [128, 192, 256])) {
+                    throw new InvalidKeyException("Default AES crypt service allows only 128, 196 and 256 bit key.")
+                }
+            }
+            shiroRememberMeManager(CookieRememberMeManager) {
+                if (cipherKeyFromConfig) cipherKey = cipherKeyFromConfig.getBytes("UTF-8")
+            }
 
             def sessionMode = grailsApplication.config.getProperty('security.shiro.session.mode')
             if (sessionMode?.equalsIgnoreCase('native')) {

--- a/src/main/groovy/shiro/ShiroGrailsPlugin.groovy
+++ b/src/main/groovy/shiro/ShiroGrailsPlugin.groovy
@@ -46,9 +46,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.core.Ordered
-
 import java.security.InvalidKeyException
-
 import static javax.servlet.DispatcherType.ERROR
 import static javax.servlet.DispatcherType.REQUEST
 
@@ -135,14 +133,16 @@ Enables Grails applications to take advantage of the Apache Shiro security layer
             }
 
             // Default remember-me manager.
-            def cipherKeyFromConfig = grailsApplication.config.getProperty('security.shiro.rememberMe.cipherKey')
+            String cipherKeyFromConfig = grailsApplication.config.getProperty('security.shiro.rememberMe.cipherKey')
             if (cipherKeyFromConfig) {
                 if (!(cipherKeyFromConfig.length() * 8 in [128, 192, 256])) {
                     throw new InvalidKeyException("Default AES crypt service allows only 128, 196 and 256 bit key.")
                 }
             }
             shiroRememberMeManager(CookieRememberMeManager) {
-                if (cipherKeyFromConfig) cipherKey = cipherKeyFromConfig.getBytes("UTF-8")
+                if (cipherKeyFromConfig) {
+                    cipherKey = cipherKeyFromConfig.getBytes("UTF-8")
+                }
             }
 
             def sessionMode = grailsApplication.config.getProperty('security.shiro.session.mode')


### PR DESCRIPTION
Made this simple implementation, please have a look.

The key generation through script can be done after you implement that JWT realm. I am using string as key as it is most convenient way to type it to application config.