### PR TITLE
feat(Shiro): upgrade shiro version 1.7.1 -> 1.13.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         grailsVersion = project.grailsVersion
-        shiroVersion = "1.7.1"
+        shiroVersion = "1.13.0"
     }
     repositories {
         mavenLocal()
@@ -15,7 +15,7 @@ buildscript {
     }
 }
 
-version "3.4"
+version "3.5"
 group "org.grails.plugins"
 
 apply plugin: "eclipse"
@@ -135,7 +135,7 @@ task shiroTest(type: Test) {
         //add the plugin
         File build = new File("$projectDir/src/test/app/shiro-tester/build.gradle")
         String content = build.text.replaceFirst('\ndependencies \\{', """dependencies {
-    compile "org.grails.plugins:grails-shiro:3.3" """)
+    compile "org.grails.plugins:grails-shiro:3.4" """)
         content = content.replaceAll(/repositories \{/, '''repositories {
 mavenLocal()''')
         build.write(content)
@@ -231,7 +231,7 @@ task shiroCliTest(type: Test) {
 
         File build = new File("$projectDir/src/test/app/cli-tester/build.gradle")
         String content = build.text.replaceFirst('\ndependencies \\{', """dependencies {
-    compile "org.grails.plugins:grails-shiro:3.3" """)
+    compile "org.grails.plugins:grails-shiro:3.4" """)
         content = content.replaceAll(/repositories \{/, '''repositories {
 mavenLocal()''')
         build.write(content)


### PR DESCRIPTION
Hi there,

here is PR for the shiro upgrade to latest jdk8 version for Grails 3.

Issue #20 

Please have a look.

The tests were running version 3.3, and main version was 3.4, not sure if that was a bug, maybe this should copy the main version, I changed to 3.4 and I think you should change it to the main again.